### PR TITLE
Using a `framework` product type and making the problem solved.

### DIFF
--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -2,7 +2,11 @@
 import ProjectDescription
 
 let dependencies = Dependencies(
-    swiftPackageManager: .init(
+    swiftPackageManager: SwiftPackageManagerDependencies(
+        productTypes: [
+            "Bootstrap": .framework,
+            "Flag": .framework,
+        ],
         projectOptions: [:]
     ),
     platforms: [.iOS, .watchOS]


### PR DESCRIPTION
This PR can solve the issue that is presented in this repo. 
Basically making the package linked dynamically (Match-O type - dynamic Library) with a product type of `framework` or `dynamicLibrary` allows for the code to act as before.

The issue remains that all of the related tree will need to become dynamic. Which is ok for development purposes but far from idle for release builds.